### PR TITLE
Fixing naming in scripts and adding half precision inference flag to CLI option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__
+Best.pkl
+results
+IMU_blur
+.idea
+

--- a/GAMD/eval.py
+++ b/GAMD/eval.py
@@ -6,6 +6,7 @@ from utils import Adder
 from data import test_dataloader
 from skimage.metrics import peak_signal_noise_ratio
 import time
+from contextlib import nullcontext
 
 
 def _eval(model, args):
@@ -16,7 +17,11 @@ def _eval(model, args):
     torch.cuda.empty_cache()
     adder = Adder()
     model.eval()
-    with torch.no_grad(), (torch.cuda.amp.autocast() if args.half_precision else None):
+
+    if args.half_precision:
+        print("Enabling half precision inference")
+
+    with torch.no_grad(), torch.cuda.amp.autocast() if args.half_precision else nullcontext():
         psnr_adder = Adder()
 
         # Hardware warm-up

--- a/GAMD/eval.py
+++ b/GAMD/eval.py
@@ -16,7 +16,7 @@ def _eval(model, args):
     torch.cuda.empty_cache()
     adder = Adder()
     model.eval()
-    with torch.no_grad():
+    with torch.no_grad(), (torch.cuda.amp.autocast() if args.half_precision else None):
         psnr_adder = Adder()
 
         # Hardware warm-up

--- a/GAMD/main.py
+++ b/GAMD/main.py
@@ -55,8 +55,8 @@ if __name__ == '__main__':
     # Test
     parser.add_argument('--test_model', type=str, default='weights/GAMD-UNet.pkl')
     parser.add_argument('--save_image', type=bool, default=False, choices=[True, False])
-    parser.add_argument('--half_precision', type=bool, default=False, choices=[True, False],
-                        description='Enable half precision inference (test only)')
+    parser.add_argument('--half_precision', default=False, action='store_true',
+                        help='Enable half precision inference (test only)')
 
     args = parser.parse_args()
     args.model_save_dir = os.path.join('results/', args.model_name, 'weights/')

--- a/GAMD/main.py
+++ b/GAMD/main.py
@@ -2,7 +2,7 @@ import os
 import torch
 import argparse
 from torch.backends import cudnn
-from models.GAMDUNet import build_net
+from models.GAMDNet import build_net
 from train import _train
 from eval import _eval
 
@@ -35,7 +35,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
     # Directories
-    parser.add_argument('--model_name', default='GAMD-UNet', choices=['GAMD-UNet'], type=str)
+    parser.add_argument('--model_name', default='GAMD-UNetPlus', choices=['GAMD-UNet', 'GAMD-UNetPlus'], type=str)
     parser.add_argument('--data_dir', type=str, default='dataset/GOPRO')
     parser.add_argument('--mode', default='test', choices=['train', 'test'], type=str)
 
@@ -55,6 +55,8 @@ if __name__ == '__main__':
     # Test
     parser.add_argument('--test_model', type=str, default='weights/GAMD-UNet.pkl')
     parser.add_argument('--save_image', type=bool, default=False, choices=[True, False])
+    parser.add_argument('--half_precision', type=bool, default=False, choices=[True, False],
+                        description='Enable half precision inference (test only)')
 
     args = parser.parse_args()
     args.model_save_dir = os.path.join('results/', args.model_name, 'weights/')


### PR DESCRIPTION
This MR fixes:
* Typo  in `main.py`:
```
from models.GAMDUNet import build_net
```
to 
```
from models.GAMDNet import build_net
```
* Setting default model type to `GAMD-UNetPlus`, the provided weights in readme weren't loading, but they load if the model type is specified to `GAMD-UNetPlus` (instead of the current default  `GAMD-UNet`)
* I could not run high-resolution inference due to an out-of-memory crash, it was resolved by enabling half-precision inference using `torch.cuda.amp.autocast()`, this doesn't seem to improve inference speed, but it reduces GPU memory usage. 
